### PR TITLE
Fixing the creation of items from MMOItems

### DIFF
--- a/plugin/src/main/java/me/dreamdevs/randomlootchest/commands/subcommands/ItemsSubCommand.java
+++ b/plugin/src/main/java/me/dreamdevs/randomlootchest/commands/subcommands/ItemsSubCommand.java
@@ -57,7 +57,7 @@ public class ItemsSubCommand implements ArgumentCommand {
                     return true;
                 }
 
-                RandomItem randomItem = new RandomItem(player.getInventory().getItemInMainHand(), chance, false);
+                RandomItem randomItem = new RandomItem(() -> player.getInventory().getItemInMainHand().clone(), chance, false);
                 RandomLootChestMain.getInstance().getItemsManager().getItems().put(id, randomItem);
                 RandomLootChestMain.getInstance().getItemsManager().save();
                 player.sendMessage(Language.ITEMS_ADDED_ITEM.toString());

--- a/plugin/src/main/java/me/dreamdevs/randomlootchest/hooks/MMOItemsHook.java
+++ b/plugin/src/main/java/me/dreamdevs/randomlootchest/hooks/MMOItemsHook.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 public class MMOItemsHook {
 
@@ -18,9 +19,10 @@ public class MMOItemsHook {
 		Util.sendPluginMessage("&aHooked into MMOItems!");
 	}
 
-	public ItemStack getItemStack(@NotNull String type, @NotNull String itemId) {
+	public Callable<ItemStack> getItemStack(@NotNull String type, @NotNull String itemId) {
 		MMOItem mmoItem = MMOItems.plugin.getMMOItem(Type.get(type), itemId);
-		return Optional.ofNullable(mmoItem).map(mmoItem1 -> mmoItem1.newBuilder().build()).orElse(null);
+		if (mmoItem == null)
+			return () -> null;
+		return () -> mmoItem.newBuilder().build();
 	}
-
 }

--- a/plugin/src/main/java/me/dreamdevs/randomlootchest/hooks/MythicMobsHook.java
+++ b/plugin/src/main/java/me/dreamdevs/randomlootchest/hooks/MythicMobsHook.java
@@ -4,6 +4,8 @@ import io.lumine.mythic.bukkit.MythicBukkit;
 import me.dreamdevs.randomlootchest.api.util.Util;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.concurrent.Callable;
+
 public class MythicMobsHook {
 
 	public static MythicMobsHook INSTANCE;
@@ -16,8 +18,8 @@ public class MythicMobsHook {
 		Util.sendPluginMessage("&aHooked into MythicMobs!");
 	}
 
-	public ItemStack getItemStack(String id) {
-		return mythicBukkit.getItemManager().getItemStack(id);
+	public Callable<ItemStack> getItemStack(String id) {
+		return () -> mythicBukkit.getItemManager().getItemStack(id);
 	}
 
 }

--- a/plugin/src/main/java/me/dreamdevs/randomlootchest/managers/ChestsManager.java
+++ b/plugin/src/main/java/me/dreamdevs/randomlootchest/managers/ChestsManager.java
@@ -29,6 +29,7 @@ import tsp.headdb.implementation.head.Head;
 
 import java.io.File;
 import java.util.*;
+import java.util.concurrent.Callable;
 
 @Getter
 public class ChestsManager {
@@ -135,7 +136,12 @@ public class ChestsManager {
                             itemStack.setItemMeta(copiedMeta);
                         }
 
-                        RandomItem randomItem = new RandomItem(itemStack, config.getDouble(CONTENTS + "." + content + ".Chance"), config.getBoolean(CONTENTS + "." + content + ".RandomAmount", false));
+                        ItemStack finalItemStack = itemStack;
+                        Callable<ItemStack> callable = () -> null;
+                        if (finalItemStack != null) {
+                            callable = finalItemStack::clone;
+                        }
+                        RandomItem randomItem = new RandomItem(callable, config.getDouble(CONTENTS + "." + content + ".Chance"), config.getBoolean(CONTENTS + "." + content + ".RandomAmount", false));
 
                         chestGame.getItemStacks().add(randomItem);
                     } catch (NullPointerException e) {

--- a/plugin/src/main/java/me/dreamdevs/randomlootchest/managers/ItemsManager.java
+++ b/plugin/src/main/java/me/dreamdevs/randomlootchest/managers/ItemsManager.java
@@ -48,7 +48,7 @@ public class ItemsManager {
                         itemsSection.getInt(string+".Amount",1), itemsSection.getString(string+".DisplayName"),
                         itemsSection.getStringList(string+".DisplayLore"), enchantments,
                         itemsSection.getBoolean(string+".Unbreakable", false), itemsSection.getBoolean(string+".Glowing",false));
-                items.put(string, new RandomItem(itemStack, section.get().getDouble(string+".Chance"), section.get().getBoolean(string+".RandomAmount", false)));
+                items.put(string, new RandomItem(() -> itemStack.clone(), section.get().getDouble(string+".Chance"), section.get().getBoolean(string+".RandomAmount", false)));
             }));
         }
 

--- a/plugin/src/main/java/me/dreamdevs/randomlootchest/objects/RandomItem.java
+++ b/plugin/src/main/java/me/dreamdevs/randomlootchest/objects/RandomItem.java
@@ -6,15 +6,16 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 @AllArgsConstructor
 public class RandomItem implements IRandomItem {
 
-    private ItemStack itemStack;
+    private Callable<ItemStack> itemStack;
     private double chance;
     private boolean randomDropAmount;
 
-    public RandomItem(ItemStack itemStack, double chance) {
+    public RandomItem(Callable<ItemStack> itemStack, double chance) {
         this.itemStack = itemStack;
         this.chance = chance;
         this.randomDropAmount = false;
@@ -22,7 +23,11 @@ public class RandomItem implements IRandomItem {
 
     @Override
     public ItemStack getItemStack() {
-        return this.itemStack;
+        try {
+            return this.itemStack.call();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
@@ -40,11 +45,13 @@ public class RandomItem implements IRandomItem {
     }
 
     public String getDisplayName() {
+        var itemStack = getItemStack();
         return (itemStack.hasItemMeta() && itemStack.getItemMeta() != null && itemStack.getItemMeta().hasDisplayName())
                 ? itemStack.getItemMeta().getDisplayName() : itemStack.getType().name();
     }
 
     public List<String> getLore() {
+        var itemStack = getItemStack();
         return (itemStack.hasItemMeta() && itemStack.getItemMeta() != null && itemStack.getItemMeta().hasLore())
                 ? itemStack.getItemMeta().getLore() : new ArrayList<>();
     }


### PR DESCRIPTION
When generating an item from MMOItems, it was noticed that the properties of the item might not be respected (for example, the restriction items count in one stack)